### PR TITLE
Only download aves

### DIFF
--- a/ebird/ebird.go
+++ b/ebird/ebird.go
@@ -206,7 +206,6 @@ func DownloadMLAsset(mlAssetID string) (string, bool, error) {
 	if err != nil {
 		return "", isPhoto, fmt.Errorf("DownloadMLAsset(%s): failed to copy asset data to file: %w", mlAssetID, err)
 	}
-
 	ext := ".mp3"
 	if isPhoto {
 		// For photos only: re-open the file to detect content type
@@ -227,9 +226,9 @@ func DownloadMLAsset(mlAssetID string) (string, bool, error) {
 		if err != nil || len(extensions) == 0 {
 			return "", isPhoto, fmt.Errorf("DownloadMLAsset(%s): failed to find file extension for mime type %s: %w", mlAssetID, mimeType, err)
 		}
-		tmpFile.Close() // Close the file before renaming it.
 		ext = extensions[0]
 	}
+	tmpFile.Close() // Close the file before renaming it.
 
 	newPath := tmpFile.Name() + ext
 	err = os.Rename(tmpFile.Name(), newPath)

--- a/ebird/ebird.go
+++ b/ebird/ebird.go
@@ -206,6 +206,7 @@ func DownloadMLAsset(mlAssetID string) (string, bool, error) {
 	if err != nil {
 		return "", isPhoto, fmt.Errorf("DownloadMLAsset(%s): failed to copy asset data to file: %w", mlAssetID, err)
 	}
+	
 	ext := ".mp3"
 	if isPhoto {
 		// For photos only: re-open the file to detect content type

--- a/ebird/ebird.go
+++ b/ebird/ebird.go
@@ -206,7 +206,7 @@ func DownloadMLAsset(mlAssetID string) (string, bool, error) {
 	if err != nil {
 		return "", isPhoto, fmt.Errorf("DownloadMLAsset(%s): failed to copy asset data to file: %w", mlAssetID, err)
 	}
-	
+
 	ext := ".mp3"
 	if isPhoto {
 		// For photos only: re-open the file to detect content type

--- a/inat/inat.go
+++ b/inat/inat.go
@@ -44,6 +44,7 @@ func (c *Client) DownloadObservations(inatUserID string, d1, d2 time.Time, field
 		q.Set("user_id", inatUserID)
 		q.Set("page", strconv.Itoa(page))
 		q.Set("per_page", strconv.Itoa(perPage))
+		q.Set("iconic_taxa[]", "Aves")
 		if !d1.IsZero() {
 			q.Set("d1", d1.Format(dateFormat))
 		}


### PR DESCRIPTION
I've been using this utility @Sajmani - thanks again!

Because I have a lot of observations, downloading the observations takes a while. To reduce the number of downloads, the query can be set to only download Birds. 

Note that this assumes #3 has already been merged