### PR TITLE
Fix crash when uploading sound files

### DIFF
--- a/birdsync.go
+++ b/birdsync.go
@@ -66,6 +66,7 @@ type stats struct {
 	afterSkips, beforeSkips, verifiableSkips, previouslySkips, fuzzySkips int
 	totalRecords, createdObservations, updatedObservations                int
 	uploadedPhotos, uploadedSounds                                        int
+	errors                                                                int
 }
 
 func main() {
@@ -112,6 +113,9 @@ func main() {
 	log.Printf("Updated %d iNaturalist observations", stats.updatedObservations)
 	log.Printf("Uploaded %d photos to iNaturalist", stats.uploadedPhotos)
 	log.Printf("Uploaded %d sounds to iNaturalist", stats.uploadedSounds)
+	if stats.errors > 0 {
+		log.Printf("Failed to upload %d media assets", stats.errors)
+	}
 }
 
 func birdsync(eBirdCSVFilename string, ebirdClient ebirdClient, inatUserID string, inatClient inatClient) stats {
@@ -197,11 +201,15 @@ func birdsync(eBirdCSVFilename string, ebirdClient ebirdClient, inatUserID strin
 				} else {
 					filename, isPhoto, err := ebirdClient.DownloadMLAsset(id)
 					if err != nil {
-						log.Fatalf("Couldn't download ML asset %s from eBird: %v", id, err)
+						log.Printf("Couldn't download ML asset %s from eBird: %v", id, err)
+						s.errors++
+						continue
 					}
 					err = inatClient.UploadMedia(filename, isPhoto, id, obs.UUID.String())
 					if err != nil {
-						log.Fatalf("Couldn't upload ML asset %s to iNaturalist: %v", id, err)
+						log.Printf("Couldn't upload ML asset %s to iNaturalist: %v", id, err)
+						s.errors++
+						continue
 					}
 					if isPhoto {
 						s.uploadedPhotos++

--- a/ebird/ebird.go
+++ b/ebird/ebird.go
@@ -169,6 +169,9 @@ func (o ObservationID) String() string {
 	return fmt.Sprintf("%s[%s]", o.SubmissionID, o.ScientificName)
 }
 
+// macaulayBaseURL is the base URL for the Macaulay Library CDN.
+const macaulayBaseURL = "https://cdn.download.ams.birds.cornell.edu/api/v2"
+
 // DownloadMLAsset downloads the photo or sound with the provided ML asset ID
 // (numbers only) and returns the local filename and whether it's a photo.
 // This file is temporary and may be deleted at any time.
@@ -177,8 +180,14 @@ func (o ObservationID) String() string {
 // we try downloading the photo file first, and if it's not there,
 // we try downloading the sound file.
 func DownloadMLAsset(mlAssetID string) (string, bool, error) {
+	return downloadMLAsset(macaulayBaseURL, mlAssetID)
+}
+
+// downloadMLAsset is the implementation of DownloadMLAsset, accepting a base
+// URL so it can be tested against a local HTTP server.
+func downloadMLAsset(baseURL, mlAssetID string) (string, bool, error) {
 	// Try fetching this ML asset as a photo
-	url := fmt.Sprintf("https://cdn.download.ams.birds.cornell.edu/api/v2/asset/%s/2400", mlAssetID)
+	url := fmt.Sprintf("%s/asset/%s/2400", baseURL, mlAssetID)
 	resp, err := http.Get(url)
 	if err != nil {
 		return "", false, fmt.Errorf("DownloadMLAsset(%s): %s: %w", mlAssetID, url, err)
@@ -187,7 +196,7 @@ func DownloadMLAsset(mlAssetID string) (string, bool, error) {
 	isPhoto := resp.StatusCode == http.StatusOK
 	if resp.StatusCode == http.StatusNotFound {
 		// Photo not found; try fetching it as a sound
-		url = fmt.Sprintf("https://cdn.download.ams.birds.cornell.edu/api/v2/asset/%s/mp3", mlAssetID)
+		url = fmt.Sprintf("%s/asset/%s/mp3", baseURL, mlAssetID)
 		resp, err = http.Get(url)
 		if err != nil {
 			return "", isPhoto, fmt.Errorf("DownloadMLAsset(%s): %s: %w", mlAssetID, url, err)
@@ -207,28 +216,14 @@ func DownloadMLAsset(mlAssetID string) (string, bool, error) {
 		return "", isPhoto, fmt.Errorf("DownloadMLAsset(%s): failed to copy asset data to file: %w", mlAssetID, err)
 	}
 
-	ext := ".mp3"
-	if isPhoto {
-		// For photos only: re-open the file to detect content type
-		_, err = tmpFile.Seek(0, 0)
-		if err != nil {
-			return "", isPhoto, fmt.Errorf("DownloadMLAsset(%s): failed to seek to beginning of temp file: %w", mlAssetID, err)
-		}
-
-		buf := make([]byte, 512) // 512 bytes is the required size for DetectContentType
-		n, err := tmpFile.Read(buf)
-		if err != nil && err != io.EOF {
-			return "", isPhoto, fmt.Errorf("DownloadMLAsset(%s): failed to read from temp file for content type detection: %w", mlAssetID, err)
-		}
-		buf = buf[:n]
-
-		mimeType := http.DetectContentType(buf)
-		extensions, err := mime.ExtensionsByType(mimeType)
-		if err != nil || len(extensions) == 0 {
-			return "", isPhoto, fmt.Errorf("DownloadMLAsset(%s): failed to find file extension for mime type %s: %w", mlAssetID, mimeType, err)
-		}
-		ext = extensions[0]
+	// Detect the file extension from the Content-Type response header.
+	// The Macaulay Library CDN sets this reliably for both photos and sounds.
+	contentType := resp.Header.Get("Content-Type")
+	extensions, err := mime.ExtensionsByType(contentType)
+	if err != nil || len(extensions) == 0 {
+		return "", isPhoto, fmt.Errorf("DownloadMLAsset(%s): failed to find file extension for mime type %q: %w", mlAssetID, contentType, err)
 	}
+	ext := extensions[0]
 	tmpFile.Close() // Close the file before renaming it.
 
 	newPath := tmpFile.Name() + ext

--- a/ebird/ebird_test.go
+++ b/ebird/ebird_test.go
@@ -1,10 +1,80 @@
 package ebird
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
+
+func TestDownloadMLAsset_Sound(t *testing.T) {
+	const assetID = "12345"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/asset/" + assetID + "/2400":
+			// Photo not found; this is a sound asset.
+			http.NotFound(w, r)
+		case "/asset/" + assetID + "/mp3":
+			w.Header().Set("Content-Type", "audio/mpeg")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("fake mp3 data"))
+		default:
+			t.Errorf("Unexpected request path: %s", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	filename, isPhoto, err := downloadMLAsset(server.URL, assetID)
+	if err != nil {
+		t.Fatalf("downloadMLAsset() error = %v", err)
+	}
+	defer os.Remove(filename)
+
+	if isPhoto {
+		t.Errorf("Expected isPhoto=false for a sound asset, got true")
+	}
+	// The extension must be a valid one for audio/mpeg (e.g. .mp3 or .m2a).
+	ext := filepath.Ext(filename)
+	validSoundExts := map[string]bool{".mp3": true, ".m2a": true, ".mp2": true, ".mpga": true}
+	if !validSoundExts[ext] {
+		t.Errorf("Expected a valid audio/mpeg extension, got %q", ext)
+	}
+}
+
+func TestDownloadMLAsset_Photo(t *testing.T) {
+	const assetID = "67890"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/asset/" + assetID + "/2400":
+			w.Header().Set("Content-Type", "image/jpeg")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("fake jpeg data"))
+		default:
+			t.Errorf("Unexpected request path: %s", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	filename, isPhoto, err := downloadMLAsset(server.URL, assetID)
+	if err != nil {
+		t.Fatalf("downloadMLAsset() error = %v", err)
+	}
+	defer os.Remove(filename)
+
+	if !isPhoto {
+		t.Errorf("Expected isPhoto=true for a photo asset, got false")
+	}
+	// The extension must be a valid one for image/jpeg (e.g. .jpeg or .jpe or .jpg).
+	ext := filepath.Ext(filename)
+	validPhotoExts := map[string]bool{".jpeg": true, ".jpe": true, ".jpg": true}
+	if !validPhotoExts[ext] {
+		t.Errorf("Expected a valid image/jpeg extension, got %q", ext)
+	}
+}
 
 func TestRecord_Observed(t *testing.T) {
 	testCases := []struct {


### PR DESCRIPTION
- Use Content-Type response header for MIME detection on both photos and sounds, replacing the hardcoded .mp3 extension for sounds
- Extract downloadMLAsset(baseURL, id) for testability
- Replace log.Fatalf with log.Printf+continue in addMedia so a single bad asset no longer crashes the whole run; report error count in summary
- Add TestDownloadMLAsset_Sound and TestDownloadMLAsset_Photo